### PR TITLE
fixing Azure DevOps NuGet Dependabot example

### DIFF
--- a/content/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates.md
+++ b/content/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates.md
@@ -896,7 +896,8 @@ registries:
   nuget-azure-devops:
     type: nuget-feed
     url: https://pkgs.dev.azure.com/.../_packaging/My_Feed/nuget/v3/index.json
-    token: ${{secrets.MY_AZURE_DEVOPS_TOKEN}}
+    username: octocat@example.com
+    password: ${{secrets.MY_AZURE_DEVOPS_TOKEN}}
 ```
 {% endraw %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

The documentation as is doesn't work - 

You receive a 401 error in the [Dependabot logs](https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/troubleshooting-dependabot-errors#investigating-errors-with-dependabot-version-updates), as shown below: 

```
{:source=>"https://pkgs.dev.azure.com/jjohanning0798/PartsUnlimited/_packaging/nuget-example/nuget/v3/index.json"}
updater | INFO <job_312553835> Checking if Microsoft.Extensions.Logging.Abstractions 2.0.0 needs updating
  proxy | 2022/03/09 22:42:52 [046] GET https://pkgs.dev.azure.com:443/jjohanning0798/PartsUnlimited/_packaging/nuget-example/nuget/v3/index.json
  proxy | 2022/03/09 22:42:52 [046] * authenticating nuget feed request (host: pkgs.dev.azure.com, bearer auth)
  proxy | 2022/03/09 22:42:52 [046] 401 https://pkgs.dev.azure.com:443/jjohanning0798/PartsUnlimited/_packaging/nuget-example/nuget/v3/index.json
updater | INFO <job_312553835> Handled error whilst updating Microsoft.Extensions.Logging.Abstractions: private_source_authentication_failure 
```

Others have had this issue, mentioned here: https://github.com/dependabot/dependabot-core/issues/3555

One of the solutions as to add a `:` somewhere in the token to force it to use basic auth, like this:

```yml
registries:
  nuget-azure-artifacts:
    type: nuget-feed
    url: https://pkgs.dev.azure.com/jjohanning0798/PartsUnlimited/_packaging/nuget-example/nuget/v3/index.json
    token: '${{ secrets.AZURE_DEVOPS_PAT }}:'  # Must be an unencoded password
```

But instead, username and password is a cleaner and more consistent solution, I think:

```yml
registries:
  nuget-azure-artifacts:
    type: nuget-feed
    url: https://pkgs.dev.azure.com/jjohanning0798/PartsUnlimited/_packaging/nuget-example/nuget/v3/index.json
    username: jjohanning0798
    password: ${{ secrets.AZURE_DEVOPS_PAT }}  # Must be an unencoded password
```


<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

On the [Dependabot version updates configuration page](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#nuget-feed), changing the Azure DevOps example to use `username` and `password` instead of `token`.


I see each of the examples here have a `token` example - and the other NuGet example is already `username` and `password` - but this just won't work with Azure DevOps as is.  

If we wanted to keep the pattern of having a `token` example and a `password` example, I would suggest we should flip the examples then.


Changing this:
![image](https://user-images.githubusercontent.com/19912012/157554128-39476f1f-95ae-46d3-a451-0f27f6a1aad3.png)

To:
![image](https://user-images.githubusercontent.com/19912012/157554551-7c060e35-e282-43ee-b881-360acecc588b.png)



### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
